### PR TITLE
JupyterHub 3.1.0に追従するための変更

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -47,6 +47,12 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --upgrade --no-cache-dir \
         setuptools \
         pip
+
+RUN pip install --no-cache-dir cliapp
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash 
+RUN apt install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+RUN npm install --global yarn
 RUN PYCURL_SSL_LIBRARY=openssl \
     pip install --no-cache-dir \
         -r /tmp/requirements.txt

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -5,7 +5,7 @@
 #
 
 # JupyterHub itself
-git+https://github.com/RCOSDP/CS-jupyterhub.git@feature/1.4.2
+git+https://github.com/RCOSDP/CS-jupyterhub.git@master
 
 ## Authenticators
 jupyterhub-firstuseauthenticator

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -52,7 +52,7 @@ jsonschema==3.2.0
     # via jupyter-telemetry
 jupyter-telemetry==0.1.0
     # via jupyterhub
-git+https://github.com/lifematics/CS-jupyterhub.git@feature/1.4.2
+git+https://github.com/RCOSDP/CS-jupyterhub.git@master
     # via
     #   -r requirements.in
     #   jupyterhub-firstuseauthenticator

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -40,12 +40,15 @@ spec:
       - port: {{ $port }}
       {{- end }}
     {{- end }}
-
+    - ports:
+        - port: 9000
     # allowed pods (hub.jupyter.org/network-access-proxy-http) --> proxy (http/https port)
     - ports:
         - port: http
+        - port: 9000
         {{- if or $manualHTTPS $manualHTTPSwithsecret }}
         - port: https
+        - port: 9443
         {{- end }}
       from:
         # source 1 - labeled pods
@@ -64,6 +67,7 @@ spec:
     # allowed pods (hub.jupyter.org/network-access-proxy-api) --> proxy (api port)
     - ports:
         - port: api
+        - port: preview-api
       from:
         # source 1 - labeled pods
         - podSelector:


### PR DESCRIPTION
JupyterHub 側を 3.1.0 に変更するのに伴い、Helmチャート側の変更を行いました。
（また、一部誤ってlifematicsリポジトリを参照する設定になってしまっていた部分を、RCOSDP側のリポジトリに戻しました）