### PR TITLE
Add fsGroupChangePolicy: OnRootMismatch

### DIFF
--- a/jupyterhub/templates/schedulable-notebook/deployment.yaml
+++ b/jupyterhub/templates/schedulable-notebook/deployment.yaml
@@ -32,6 +32,7 @@ spec:
             claimName: schedulable-notebook-home
       securityContext:
         fsGroup: {{ .Values.hub.fsGid }}
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - command:
           - jupyterhub-singleuser


### PR DESCRIPTION
Schedulable-notebookのPod再作成時に、マウントされる~/.ssh以下のファイルも含めてすべてグループ向けのパーミッションが付加されてしまう問題の対策として、securityContext に`fsGroupChangePolicy: OnRootMismatch`を追加しました。